### PR TITLE
Delete .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-#DATABASE_URL="postgresql://localhost/hello_world"
-


### PR DESCRIPTION
Actually, @rbs233 just thought of this..  If we need to "comment out" the `.env` file when you upload to Heroku, we can actually just delete it from github because it's only necessary for running the db locally.